### PR TITLE
12: `MasterCluster#initialize` controlled by `autoInitialized: Boolean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Both in-memory and persistent tasks are available at the same time, and can be u
 
 ## prototype
 
-  `constructor(taskMap: Object, { port: Integer, maxAvailableWorkers: Integer, refreshRate: Integer, inMemoryOnly: Boolean, messageBroker: function, logs: String, keepAlive: String | Integer })`
+  `constructor(taskMap: Object, { port: Integer, maxAvailableWorkers: Integer, refreshRate: Integer, inMemoryOnly: Boolean, messageBroker: function, logs: String, keepAlive: String | Integer, autoInitialize: Boolean })`
   - `taskMap`: a map of functions associated to a `taskType`
   - `maxAvailableWorkers`: maximum number of child process (cores), default is set to system maximum
   - `port`: server port for child process servers, default set to `3008`
@@ -76,6 +76,7 @@ Both in-memory and persistent tasks are available at the same time, and can be u
     - some `Integer` value will have the system not shutdown workers until the number passed in milliseconds has passed since last a job was available to be picked up by a worker
     
     **NOTE:** default behavior when `keepAlive` is not set is to only keep alive workers when there are jobs available to be picked up by them. 
+  - `autoInitialize`: an optional parameter that controls whether the system will automatically initialize the cluster's polling for jobs when the `MasterCluster` is created. Default is set to `true`.
 
   `Cluster.isMaster()`: `true` if this process is the master<br/>
 

--- a/src/Cluster/MasterCluster.js
+++ b/src/Cluster/MasterCluster.js
@@ -153,13 +153,25 @@ class MasterCluster extends StaticCluster {
   }
 
   /**
-   * Starts the Cluster._run interval call determined by this.refreshRate
+   * Starts the Cluster._run interval call at the rate determined by this.refreshRate
    */
   initialize () {
-    if (this.setIntervalHandle != null) {
-      Meteor.clearInterval(this.setIntervalHandle)
+    this.setRefreshRate(this.refreshRate)
+  }
+
+  /**
+   * Set the refresh rate at which Cluster._run is called and restart the interval call at the new
+   * rate
+   * 
+   * @param { Integer } delay 
+   */
+  setRefreshRate (delay) {
+    this.refreshRate = delay
+
+    if (this.interval != null) {
+      Meteor.clearInterval(this.interval)
     }
-    this.setIntervalHandle = Meteor.setInterval(() => this._run(), this.refreshRate)
+    this.interval = Meteor.setInterval(() => this._run(), delay)
   }
 }
 


### PR DESCRIPTION
# Description
Adds a flag `autoInitialize: Boolean`(defaults to true for backwards compatibility) which can be passed to the `MasterCluster` constructor to disable the auto startup of the cluster. A method `initialize` can then be called to manually start the cluster. 

# Closed Issues
closes #12 